### PR TITLE
tlv: Mark test module as `pub(crate)`

### DIFF
--- a/type-length-value-derive-test/src/lib.rs
+++ b/type-length-value-derive-test/src/lib.rs
@@ -4,7 +4,7 @@
 //! testing the macro itself.
 
 #[cfg(test)]
-pub mod test {
+pub(crate) mod test {
     use {
         borsh::{BorshDeserialize, BorshSerialize},
         solana_borsh::v1::{get_instance_packed_len, try_from_slice_unchecked},


### PR DESCRIPTION
#### Problem

The downstream agave jobs are failing after the upgrade to Rust 1.84, because the lint for public modules needing documentation is getting tripped.

#### Summary of changes

Mark the test module as `pub(crate)` since it shouldn't be used outside.