### PR TITLE
program-error: Remove solana-program usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6612,8 +6612,11 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serial_test",
- "solana-program",
- "solana-sdk",
+ "solana-decode-error",
+ "solana-msg",
+ "solana-program-error",
+ "solana-sha256-hasher",
+ "solana-sysvar",
  "spl-program-error-derive",
  "thiserror 2.0.11",
 ]

--- a/program-error/Cargo.toml
+++ b/program-error/Cargo.toml
@@ -10,14 +10,17 @@ edition = "2021"
 [dependencies]
 num-derive = "0.4"
 num-traits = "0.2"
-solana-program = "2.2.1"
+solana-decode-error = "2.2.1"
+solana-msg = "2.2.1"
+solana-program-error = "2.2.1"
 spl-program-error-derive = { version = "0.4.1", path = "./derive" }
 thiserror = "2.0"
 
 [dev-dependencies]
 lazy_static = "1.5"
 serial_test = "3.2"
-solana-sdk = "2.1.0"
+solana-sha256-hasher = "2.2.1"
+solana-sysvar = "2.2.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program-error/README.md
+++ b/program-error/README.md
@@ -2,9 +2,9 @@
 
 Macros for implementing error-based traits on enums.
 
-- `#[derive(IntoProgramError)]`: automatically derives the trait `From<Self> for solana_program::program_error::ProgramError`.
-- `#[derive(DecodeError)]`: automatically derives the trait `solana_program::decode_error::DecodeError<T>`.
-- `#[derive(PrintProgramError)]`: automatically derives the trait `solana_program::program_error::PrintProgramError`.
+- `#[derive(IntoProgramError)]`: automatically derives the trait `From<Self> for solana_program_error::ProgramError`.
+- `#[derive(DecodeError)]`: automatically derives the trait `solana_decode_error::DecodeError<T>`.
+- `#[derive(PrintProgramError)]`: automatically derives the trait `solana_program_error::PrintProgramError`.
 - `#[spl_program_error]`: Automatically derives all below traits:
   - `Clone`
   - `Debug`
@@ -18,7 +18,7 @@ Macros for implementing error-based traits on enums.
 
 ### `#[derive(IntoProgramError)]`
 
-This derive macro automatically derives the trait `From<Self> for solana_program::program_error::ProgramError`.
+This derive macro automatically derives the trait `From<Self> for solana_program_error::ProgramError`.
 
 Your enum must implement the following traits in order for this macro to work:
 
@@ -48,7 +48,7 @@ pub enum ExampleError {
 
 ### `#[derive(DecodeError)]`
 
-This derive macro automatically derives the trait `solana_program::decode_error::DecodeError<T>`.
+This derive macro automatically derives the trait `solana_decode_error::DecodeError<T>`.
 
 Your enum must implement the following traits in order for this macro to work:
 
@@ -86,7 +86,7 @@ pub enum ExampleError {
 
 ### `#[derive(PrintProgramError)]`
 
-This derive macro automatically derives the trait `solana_program::program_error::PrintProgramError`.
+This derive macro automatically derives the trait `solana_program_error::PrintProgramError`.
 
 Your enum must implement the following traits in order for this macro to work:
 
@@ -149,10 +149,10 @@ It also imports the required crates so you don't have to in your program:
 Just annotate your enum...
 
 ```rust
-use solana_program_error_derive::*;
+use spl_program_error_derive::*;
 
 /// Example error
-#[solana_program_error]
+#[spl_program_error]
 pub enum ExampleError {
     /// Mint has no mint authority
     #[error("Mint has no mint authority")]
@@ -261,29 +261,29 @@ impl ::core::cmp::PartialEq for ExampleError {
         __self_tag == __arg1_tag
     }
 }
-impl From<ExampleError> for solana_program::program_error::ProgramError {
+impl From<ExampleError> for solana_program_error::ProgramError {
     fn from(e: ExampleError) -> Self {
-        solana_program::program_error::ProgramError::Custom(e as u32)
+        solana_program_error::ProgramError::Custom(e as u32)
     }
 }
-impl<T> solana_program::decode_error::DecodeError<T> for ExampleError {
+impl<T> solana_decode_error::DecodeError<T> for ExampleError {
     fn type_of() -> &'static str {
         "ExampleError"
     }
 }
-impl solana_program::program_error::PrintProgramError for ExampleError {
+impl solana_program_error::PrintProgramError for ExampleError {
     fn print<E>(&self)
     where
-        E: 'static + std::error::Error + solana_program::decode_error::DecodeError<E>
-            + solana_program::program_error::PrintProgramError
+        E: 'static + std::error::Error + solana_decode_error::DecodeError<E>
+            + solana_program_error::PrintProgramError
             + num_traits::FromPrimitive,
     {
         match self {
             ExampleError::MintHasNoMintAuthority => {
-                ::solana_program::log::sol_log("Mint has no mint authority")
+                ::solana_msg::sol_log("Mint has no mint authority")
             }
             ExampleError::IncorrectMintAuthority => {
-                ::solana_program::log::sol_log(
+                ::solana_msg::sol_log(
                     "Incorrect mint authority has signed the instruction",
                 )
             }

--- a/program-error/derive/src/lib.rs
+++ b/program-error/derive/src/lib.rs
@@ -23,7 +23,7 @@ use {
     syn::{parse_macro_input, ItemEnum},
 };
 
-/// Derive macro to add `Into<solana_program::program_error::ProgramError>`
+/// Derive macro to add `Into<solana_program_error::ProgramError>`
 /// trait
 #[proc_macro_derive(IntoProgramError)]
 pub fn into_program_error(input: TokenStream) -> TokenStream {
@@ -33,14 +33,14 @@ pub fn into_program_error(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Derive macro to add `solana_program::decode_error::DecodeError` trait
+/// Derive macro to add `solana_decode_error::DecodeError` trait
 #[proc_macro_derive(DecodeError)]
 pub fn decode_error(input: TokenStream) -> TokenStream {
     let ItemEnum { ident, .. } = parse_macro_input!(input as ItemEnum);
     MacroType::DecodeError { ident }.generate_tokens().into()
 }
 
-/// Derive macro to add `solana_program::program_error::PrintProgramError` trait
+/// Derive macro to add `solana_program_error::PrintProgramError` trait
 #[proc_macro_derive(PrintProgramError)]
 pub fn print_program_error(input: TokenStream) -> TokenStream {
     let ItemEnum {
@@ -60,9 +60,9 @@ pub fn print_program_error(input: TokenStream) -> TokenStream {
 /// - `PartialEq`
 /// - `thiserror::Error`
 /// - `num_derive::FromPrimitive`
-/// - `Into<solana_program::program_error::ProgramError>`
-/// - `solana_program::decode_error::DecodeError`
-/// - `solana_program::program_error::PrintProgramError`
+/// - `Into<solana_program_error::ProgramError>`
+/// - `solana_decode_error::DecodeError`
+/// - `solana_program_error::PrintProgramError`
 ///
 /// Optionally, you can add `hash_error_code_start: u32` argument to create
 /// a unique `u32` _starting_ error codes from the names of the enum variants.

--- a/program-error/src/lib.rs
+++ b/program-error/src/lib.rs
@@ -9,7 +9,7 @@ extern crate self as spl_program_error;
 // Make these available downstream for the macro to work without
 // additional imports
 pub use {
-    num_derive, num_traits, solana_program,
+    num_derive, num_traits, solana_decode_error, solana_msg, solana_program_error,
     spl_program_error_derive::{
         spl_program_error, DecodeError, IntoProgramError, PrintProgramError,
     },

--- a/program-error/tests/bench.rs
+++ b/program-error/tests/bench.rs
@@ -12,32 +12,32 @@ pub enum ExampleError {
     IncorrectMintAuthority,
 }
 
-impl From<ExampleError> for solana_program::program_error::ProgramError {
+impl From<ExampleError> for solana_program_error::ProgramError {
     fn from(e: ExampleError) -> Self {
-        solana_program::program_error::ProgramError::Custom(e as u32)
+        solana_program_error::ProgramError::Custom(e as u32)
     }
 }
-impl<T> solana_program::decode_error::DecodeError<T> for ExampleError {
+impl<T> solana_decode_error::DecodeError<T> for ExampleError {
     fn type_of() -> &'static str {
         "ExampleError"
     }
 }
 
-impl solana_program::program_error::PrintProgramError for ExampleError {
+impl solana_program_error::PrintProgramError for ExampleError {
     fn print<E>(&self)
     where
         E: 'static
             + std::error::Error
-            + solana_program::decode_error::DecodeError<E>
-            + solana_program::program_error::PrintProgramError
+            + solana_decode_error::DecodeError<E>
+            + solana_program_error::PrintProgramError
             + num_traits::FromPrimitive,
     {
         match self {
             ExampleError::MintHasNoMintAuthority => {
-                solana_program::msg!("Mint has no mint authority")
+                solana_msg::msg!("Mint has no mint authority")
             }
             ExampleError::IncorrectMintAuthority => {
-                solana_program::msg!("Incorrect mint authority has signed the instruction")
+                solana_msg::msg!("Incorrect mint authority has signed the instruction")
             }
         }
     }

--- a/program-error/tests/mod.rs
+++ b/program-error/tests/mod.rs
@@ -9,10 +9,8 @@ mod tests {
     use {
         super::*,
         serial_test::serial,
-        solana_program::{
-            decode_error::DecodeError,
-            program_error::{PrintProgramError, ProgramError},
-        },
+        solana_decode_error::DecodeError,
+        solana_program_error::{PrintProgramError, ProgramError},
         std::sync::{Arc, RwLock},
     };
 
@@ -24,7 +22,7 @@ mod tests {
         *EXPECTED_DATA.write().unwrap() = expected_data;
     }
     pub struct SyscallStubs {}
-    impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
+    impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
         fn sol_log(&self, message: &str) {
             assert_eq!(
                 message,
@@ -73,7 +71,7 @@ mod tests {
         static ONCE: Once = Once::new();
 
         ONCE.call_once(|| {
-            solana_sdk::program_stubs::set_syscall_stubs(Box::new(SyscallStubs {}));
+            solana_sysvar::program_stubs::set_syscall_stubs(Box::new(SyscallStubs {}));
         });
         // `Into<ProgramError>`
         assert_eq!(
@@ -112,7 +110,7 @@ mod tests {
         static ONCE: Once = Once::new();
 
         ONCE.call_once(|| {
-            solana_sdk::program_stubs::set_syscall_stubs(Box::new(SyscallStubs {}));
+            solana_sysvar::program_stubs::set_syscall_stubs(Box::new(SyscallStubs {}));
         });
         // `Into<ProgramError>`
         assert_eq!(

--- a/program-error/tests/spl.rs
+++ b/program-error/tests/spl.rs
@@ -42,7 +42,7 @@ fn test_library_error_codes() {
     fn get_error_code_check(hash_input: &str) -> u32 {
         let mut nonce: u32 = 0;
         loop {
-            let hash = solana_program::hash::hashv(&[hash_input.as_bytes(), &nonce.to_le_bytes()]);
+            let hash = solana_sha256_hasher::hashv(&[hash_input.as_bytes(), &nonce.to_le_bytes()]);
             let mut bytes = [0u8; 4];
             bytes.copy_from_slice(&hash.to_bytes()[13..17]);
             let error_code = u32::from_le_bytes(bytes);
@@ -73,9 +73,9 @@ fn test_library_error_codes() {
     );
 }
 
-/// Example error with solana_program crate set
-#[spl_program_error(solana_program = "solana_program")]
-enum ExampleSolanaProgramCrateError {
+/// Example error with solana_program_error crate set
+#[spl_program_error(solana_program_error = "solana_program_error")]
+enum ExampleSolanaProgramError {
     /// This is a very informative error
     #[error("This is a very informative error")]
     VeryInformativeError,
@@ -86,6 +86,23 @@ enum ExampleSolanaProgramCrateError {
 
 /// Tests that all macros compile
 #[test]
-fn test_macros_compile_with_solana_program_crate() {
-    let _ = ExampleSolanaProgramCrateError::VeryInformativeError;
+fn test_macros_compile_with_solana_program_error_crate() {
+    let _ = ExampleSolanaProgramError::VeryInformativeError;
+}
+
+/// Example error with solana_decode_error crate set
+#[spl_program_error(solana_decode_error = "solana_decode_error")]
+enum ExampleSolanaDecodeError {
+    /// This is a very informative error
+    #[error("This is a very informative error")]
+    VeryInformativeError,
+    /// This is a super important error
+    #[error("This is a super important error")]
+    SuperImportantError,
+}
+
+/// Tests that all macros compile
+#[test]
+fn test_macros_compile_with_solana_decode_error_crate() {
+    let _ = ExampleSolanaDecodeError::VeryInformativeError;
 }


### PR DESCRIPTION
#### Problem

A few SPL programs use `spl-program-error`, but it brings in solana-program by default, which makes program-error definitions very heavy to include.

#### Summary of changes

Split up the usage of `solana-program-error` and `solana-decode-error`, parametrize them just like `solana-program` used to be.

As part of this change, I *didn't* parametrize `solana-msg`, since that just resolves to a simple syscall. We could inline the syscall and avoid its usage entirely, but that seems a bit harsh.

With this change, we go from building 192 crates to 40, and build times go from ~6.5s to ~2.2s on my machine.

NOTE: This is a breaking change.