### PR TITLE
tlv: Enable solana-pubkey feature, add testing

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,6 +16,9 @@ inputs:
   rustfmt:
     description: Install Rustfmt if `true`. Defaults to `false`.
     required: false
+  nightly-toolchain:
+    description: Install nightly toolchain if `true`. Defaults to `false`.
+    required: false
   solana:
     description: Install Solana if `true`. Defaults to `false`.
     required: false
@@ -44,15 +47,21 @@ runs:
       if: ${{ inputs.rustfmt == 'true' }}
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ env.TOOLCHAIN_FORMAT }}
+        toolchain: ${{ env.TOOLCHAIN_NIGHTLY }}
         components: rustfmt
 
     - name: Install Clippy
       if: ${{ inputs.clippy == 'true' }}
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ env.TOOLCHAIN_LINT }}
+        toolchain: ${{ env.TOOLCHAIN_NIGHTLY }}
         components: clippy
+
+    - name: Install nightly toolchain
+      if: ${{ inputs.nightly-toolchain == 'true' }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.TOOLCHAIN_NIGHTLY }}
 
     - name: Install Solana
       if: ${{ inputs.solana == 'true' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          rustfmt: true
+          nightly-toolchain: true
           cargo-cache-key: cargo-hack-check
           cargo-cache-fallback-key: cargo-hack
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,6 +127,28 @@ jobs:
       - name: Build
         run: pnpm ${{ matrix.library }}:build
 
+  hack_rust:
+    name: Check Powerset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          rustfmt: true
+          cargo-cache-key: cargo-hack-check
+          cargo-cache-fallback-key: cargo-hack
+
+      - name: Install cargo-hack
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: Hack check
+        run: pnpm rust:hack
+
   test_rust:
     name: Test Rust
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,7 @@ solana = "2.2.0"
 # Specify Rust toolchains for rustfmt, clippy, and build.
 # Any unprovided toolchains default to stable.
 [workspace.metadata.toolchains]
-format = "nightly-2024-11-22"
-lint = "nightly-2024-11-22"
+nightly = "nightly-2024-11-22"
 
 [workspace.metadata.spellcheck]
 config = "scripts/spellcheck.toml"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "template:upgrade": "zx ./scripts/upgrade-template.mjs",
     "rust:spellcheck": "cargo spellcheck --code 1",
     "rust:audit": "zx ./scripts/rust/audit.mjs",
+    "rust:hack": "zx ./scripts/rust/hack.mjs",
     "rust:semver": "cargo semver-checks"
   },
   "devDependencies": {

--- a/scripts/ci/set-env.mjs
+++ b/scripts/ci/set-env.mjs
@@ -2,5 +2,4 @@
 import { getSolanaVersion, getToolchain } from '../utils.mjs';
 
 await $`echo "SOLANA_VERSION=${getSolanaVersion()}" >> $GITHUB_ENV`;
-await $`echo "TOOLCHAIN_FORMAT=${getToolchain('format')}" >> $GITHUB_ENV`;
-await $`echo "TOOLCHAIN_LINT=${getToolchain('lint')}" >> $GITHUB_ENV`;
+await $`echo "TOOLCHAIN_NIGHTLY=${getToolchain('nightly')}" >> $GITHUB_ENV`;

--- a/scripts/rust/format.mjs
+++ b/scripts/rust/format.mjs
@@ -12,7 +12,7 @@ const [folder, ...formatArgs] = cliArguments();
 
 const fix = popArgument(formatArgs, '--fix');
 const [cargoArgs, fmtArgs] = partitionArguments(formatArgs, '--');
-const toolchain = getToolchainArgument('format');
+const toolchain = getToolchainArgument('nightly');
 
 const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
 

--- a/scripts/rust/hack.mjs
+++ b/scripts/rust/hack.mjs
@@ -3,4 +3,4 @@ import 'zx/globals';
 import { cliArguments, getToolchainArgument } from '../utils.mjs';
 
 const toolchain = getToolchainArgument('nightly');
-await $`cargo ${toolchain} hack check --all-targets ${cliArguments()}`;
+await $`cargo ${toolchain} hack check --all-targets --feature-powerset ${cliArguments()}`;

--- a/scripts/rust/hack.mjs
+++ b/scripts/rust/hack.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import {
+  cliArguments,
+  getToolchainArgument,
+  popArgument,
+  workingDirectory,
+} from '../utils.mjs';
+
+const toolchain = getToolchainArgument('lint');
+await $`cargo ${toolchain} hack check --all-targets ${cliArguments()}`;

--- a/scripts/rust/hack.mjs
+++ b/scripts/rust/hack.mjs
@@ -1,11 +1,6 @@
 #!/usr/bin/env zx
 import 'zx/globals';
-import {
-  cliArguments,
-  getToolchainArgument,
-  popArgument,
-  workingDirectory,
-} from '../utils.mjs';
+import { cliArguments, getToolchainArgument } from '../utils.mjs';
 
-const toolchain = getToolchainArgument('lint');
+const toolchain = getToolchainArgument('nightly');
 await $`cargo ${toolchain} hack check --all-targets ${cliArguments()}`;

--- a/scripts/rust/lint.mjs
+++ b/scripts/rust/lint.mjs
@@ -21,7 +21,7 @@ const lintArgs = [
 ];
 
 const fix = popArgument(lintArgs, '--fix');
-const toolchain = getToolchainArgument('lint');
+const toolchain = getToolchainArgument('nightly');
 
 const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
 

--- a/tlv-account-resolution/Cargo.toml
+++ b/tlv-account-resolution/Cargo.toml
@@ -21,7 +21,7 @@ solana-decode-error = "2.2.1"
 solana-instruction = { version = "2.2.1", features = ["std"] }
 solana-program-error = "2.2.1"
 solana-msg = "2.2.1"
-solana-pubkey = "2.2.1"
+solana-pubkey = { version = "2.2.1", features = ["curve25519"] }
 spl-discriminator = { version = "0.4.0", path = "../discriminator" }
 spl-program-error = { version = "0.6.0", path = "../program-error" }
 spl-pod = { version = "0.5.0", path = "../pod" }


### PR DESCRIPTION
#### Problem

The tlv-account-resolution library currently fails to build `cargo check` because the `curve25519` feature is not enabled.

#### Summary of changes

Enable the feature. At the same time, add a CI step for running `cargo hack check --all-features` on the repo to catch this.

I also got a little annoyed about all the redundant toolchain declarations that are all just the nightly toolchain, so I combined them all for the hack step.