### PR TITLE
Publish: Use package name minus "spl-" instead of dir for tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ nightly = "nightly-2024-11-22"
 
 [workspace.metadata.spellcheck]
 config = "scripts/spellcheck.toml"
+
+[workspace.metadata.release]
+pre-release-commit-message = "Publish {{crate_name}} v{{version}}"
+tag-message = "Publish {{crate_name}} v{{version}}"
+consolidate-commits = false

--- a/scripts/rust/publish.mjs
+++ b/scripts/rust/publish.mjs
@@ -16,7 +16,7 @@ cd(path.join(workingDirectory, folder));
 const packageToml = getCargo(folder).package;
 const oldVersion = packageToml.version;
 const packageName = packageToml.name;
-const tagName = path.basename(folder);
+const tagName = packageName.replace(/spl-/, '');
 
 // Publish the new version, commit the repo change, tag it, and push it all.
 const releaseArgs = dryRun


### PR DESCRIPTION
#### Problem

The repo has some nested packages, such as `program-error/derive`, but the publish script will use the basename for the tag name. This means that we'll publish a tag called `derive`, rather than `program-error-derive`.

#### Summary of changes

Change the tag name to the package name minus `spl-`. Also, the publish commit is a generic message, so customize it.
