### PR TITLE
CI: Move semver check to publish job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,26 +68,6 @@ jobs:
       - name: Run cargo-audit
         run: pnpm rust:audit
 
-  semver_rust:
-    name: Check semver Rust
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup
-        with:
-          cargo-cache-key: cargo-semver
-
-      - name: Install cargo-audit
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-semver-checks
-
-      - name: Run semver checks
-        run: pnpm rust:semver
-
   spellcheck_rust:
     name: Spellcheck Rust
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -27,15 +27,6 @@ on:
           - patch
           - minor
           - major
-          - rc
-          - beta
-          - alpha
-          - release
-          - version
-      version:
-        description: Version (used with level "version")
-        required: false
-        type: string
       dry_run:
         description: Dry run
         required: true
@@ -63,6 +54,11 @@ jobs:
           cargo-cache-key: cargo-test-publish-${{ inputs.package_path }}
           cargo-cache-fallback-key: cargo-test-publish
 
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks
+
       - name: Format
         run: pnpm zx ./scripts/rust/format.mjs "${{ inputs.package_path }}"
 
@@ -71,6 +67,9 @@ jobs:
 
       - name: Test
         run: pnpm zx ./scripts/rust/test.mjs "${{ inputs.package_path }}"
+
+      - name: Check semver
+        run: pnpm rust:semver ${{ inputs.package_path }} --release-type ${{ inputs.level }}
 
   publish:
     name: Publish Rust Crate
@@ -113,19 +112,13 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          if [ "${{ inputs.level }}" == "version" ]; then
-            LEVEL=${{ inputs.version }}
-          else
-            LEVEL=${{ inputs.level }}
-          fi
-
           if [ "${{ inputs.dry_run }}" == "true" ]; then
             OPTIONS="--dry-run"
           else
             OPTIONS=""
           fi
 
-          pnpm rust:publish "${{ inputs.package_path }}" $LEVEL $OPTIONS
+          pnpm rust:publish "${{ inputs.package_path }}" "${{ inputs.level }}" $OPTIONS
 
       - name: Generate a changelog
         if: github.event.inputs.create_release == 'true'

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "rust:audit": "zx ./scripts/rust/audit.mjs",
     "rust:publish": "zx ./scripts/rust/publish.mjs",
     "rust:hack": "zx ./scripts/rust/hack.mjs",
-    "rust:semver": "cargo semver-checks"
+    "rust:semver": "zx ./scripts/rust/semver.mjs"
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",

--- a/scripts/rust/semver.mjs
+++ b/scripts/rust/semver.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import { cliArguments, getCargo, workingDirectory } from '../utils.mjs';
+
+const [folder, ...args] = cliArguments();
+const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
+await $`cargo semver-checks --manifest-path ${manifestPath} ${args}`;


### PR DESCRIPTION
#### Problem

The semver check job can be a bit noisy and give a lot of negatives, which can hamper development.

#### Summary of changes

Run the semver checks only during publish, similar to how pinocchio does things.