### PR TITLE
temp downgrade cargo release

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -91,10 +91,10 @@ jobs:
           cargo-cache-key: cargo-publish-${{ inputs.package_path }}
           cargo-cache-fallback-key: cargo-publish
 
-      - name: Install Cargo Release
-        # FIXME this version constraint may be removed when we go to rustc version >=1.85
-        # the minimum rustc version for cargo-release was changed on a patch release
-        run: which cargo-release || cargo install cargo-release --version 0.25.17
+      - name: Install cargo-release
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-release
 
       - name: Ensure CARGO_REGISTRY_TOKEN variable is set
         env:

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -92,7 +92,9 @@ jobs:
           cargo-cache-fallback-key: cargo-publish
 
       - name: Install Cargo Release
-        run: which cargo-release || cargo install cargo-release
+        # FIXME this version constraint may be removed when we go to rustc version >=1.85
+        # the minimum rustc version for cargo-release was changed on a patch release
+        run: which cargo-release || cargo install cargo-release --version 0.25.17
 
       - name: Ensure CARGO_REGISTRY_TOKEN variable is set
         env:


### PR DESCRIPTION
from crate publish dryrun:

```
Run which cargo-release || cargo install cargo-release
  which cargo-release || cargo install cargo-release
  shell: /usr/bin/bash -e {0}
  env:
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
    SOLANA_VERSION: [2](https://github.com/solana-program/libraries/actions/runs/14447836275/job/40512827106#step:5:2).2.0
    TOOLCHAIN_NIGHTLY: nightly-2024-11-22
info: syncing channel updates for '1.84.1-x86_64-unknown-linux-gnu'
...
    Updating crates.io index
error: cannot install package `cargo-release 0.25.18`, it requires rustc 1.85 or newer, while the currently active rustc version is 1.84.1
`cargo-release 0.25.17` supports rustc 1.82
Error: Process completed with exit code 101.
```

since we are advancing our `rust_toolchain.toml` in line with (agave? sdk? one of the ex-monorepos) it seems more prudent to temporarily downgrade this than mess with that