### PR TITLE
generic-token: make consts used in rpc pub

### DIFF
--- a/generic-token/src/token.rs
+++ b/generic-token/src/token.rs
@@ -19,8 +19,8 @@ solana_pubkey::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
         close_authority: COption<Pubkey>,
     }
 */
-const SPL_TOKEN_ACCOUNT_MINT_OFFSET: usize = 0;
-const SPL_TOKEN_ACCOUNT_OWNER_OFFSET: usize = 32;
+pub const SPL_TOKEN_ACCOUNT_MINT_OFFSET: usize = 0;
+pub const SPL_TOKEN_ACCOUNT_OWNER_OFFSET: usize = 32;
 const SPL_TOKEN_ACCOUNT_AMOUNT_OFFSET: usize = 64;
 const SPL_TOKEN_ACCOUNT_STATE_OFFSET: usize = 108;
 pub(crate) const SPL_TOKEN_ACCOUNT_LENGTH: usize = 165;

--- a/generic-token/src/token_2022.rs
+++ b/generic-token/src/token_2022.rs
@@ -8,7 +8,7 @@ use crate::token::{
 solana_pubkey::declare_id!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 
 // `spl_token_program_2022::extension::AccountType::Account` ordinal value
-const ACCOUNTTYPE_ACCOUNT: u8 = 2;
+pub const ACCOUNTTYPE_ACCOUNT: u8 = 2;
 
 // Token2022 enforces that TLV data cannot make a Mint or Account that is precisely
 // the length of a Multisig, to allow them to be distinguished.


### PR DESCRIPTION
i took all of these private but im marking the ones used for rpc memcmps pub again

cc @joncinque for visibility but this is trivial enough ill just publish it