### PR TITLE
ListView: add deref

### DIFF
--- a/pod/src/list/list_trait.rs
+++ b/pod/src/list/list_trait.rs
@@ -27,6 +27,12 @@ pub trait List {
     /// Returns a read-only slice of the items currently in the list.
     fn as_slice(&self) -> &[Self::Item];
 
+    /// Returns a reference to an element at a given index or `None` if the
+    /// index is out of bounds.
+    fn get(&self, index: usize) -> Option<&Self::Item> {
+        self.as_slice().get(index)
+    }
+
     /// Returns a read-only iterator over the list.
     fn iter(&self) -> Iter<'_, Self::Item> {
         self.as_slice().iter()

--- a/pod/src/list/list_trait.rs
+++ b/pod/src/list/list_trait.rs
@@ -2,41 +2,19 @@ use {
     crate::{list::ListView, pod_length::PodLength},
     bytemuck::Pod,
     solana_program_error::ProgramError,
-    std::slice::Iter,
+    std::ops::Deref,
 };
 
 /// A trait to abstract the shared, read-only behavior
 /// between `ListViewReadOnly` and `ListViewMut`.
-pub trait List {
+pub trait List: Deref<Target = [Self::Item]> {
     /// The type of the items stored in the list.
     type Item: Pod;
     /// Length prefix type used (`PodU16`, `PodU32`, …).
     type Length: PodLength;
 
-    /// Returns the number of items in the list.
-    fn len(&self) -> usize;
-
-    /// Returns `true` if the list contains no items.
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     /// Returns the total number of items that can be stored in the list.
     fn capacity(&self) -> usize;
-
-    /// Returns a read-only slice of the items currently in the list.
-    fn as_slice(&self) -> &[Self::Item];
-
-    /// Returns a reference to an element at a given index or `None` if the
-    /// index is out of bounds.
-    fn get(&self, index: usize) -> Option<&Self::Item> {
-        self.as_slice().get(index)
-    }
-
-    /// Returns a read-only iterator over the list.
-    fn iter(&self) -> Iter<'_, Self::Item> {
-        self.as_slice().iter()
-    }
 
     /// Returns the number of **bytes currently occupied** by the live elements
     fn bytes_used(&self) -> Result<usize, ProgramError> {

--- a/pod/src/list/list_view.rs
+++ b/pod/src/list/list_view.rs
@@ -342,12 +342,12 @@ mod tests {
         let view_ro = ListView::<u32, PodU32>::unpack(&buf).unwrap();
         assert_eq!(view_ro.len(), length as usize);
         assert_eq!(view_ro.capacity(), capacity);
-        assert_eq!(view_ro.as_slice(), &items[..]);
+        assert_eq!(*view_ro, items[..]);
 
         let view_mut = ListView::<u32, PodU32>::unpack_mut(&mut buf).unwrap();
         assert_eq!(view_mut.len(), length as usize);
         assert_eq!(view_mut.capacity(), capacity);
-        assert_eq!(view_mut.as_slice(), &items[..]);
+        assert_eq!(*view_mut, items[..]);
     }
 
     #[test]
@@ -375,12 +375,12 @@ mod tests {
         let view_ro = ListView::<u64, PodU32>::unpack(&buf).unwrap();
         assert_eq!(view_ro.len(), length as usize);
         assert_eq!(view_ro.capacity(), capacity);
-        assert_eq!(view_ro.as_slice(), &items[..]);
+        assert_eq!(*view_ro, items[..]);
 
         let view_mut = ListView::<u64, PodU32>::unpack_mut(&mut buf).unwrap();
         assert_eq!(view_mut.len(), length as usize);
         assert_eq!(view_mut.capacity(), capacity);
-        assert_eq!(view_mut.as_slice(), &items[..]);
+        assert_eq!(*view_mut, items[..]);
     }
 
     #[test]
@@ -398,13 +398,13 @@ mod tests {
         assert_eq!(view_ro.len(), 0);
         assert_eq!(view_ro.capacity(), capacity);
         assert!(view_ro.is_empty());
-        assert_eq!(view_ro.as_slice(), &[] as &[u32]);
+        assert_eq!(&*view_ro, &[] as &[u32]);
 
         let view_mut = ListView::<u32, PodU32>::unpack_mut(&mut buf).unwrap();
         assert_eq!(view_mut.len(), 0);
         assert_eq!(view_mut.capacity(), capacity);
         assert!(view_mut.is_empty());
-        assert_eq!(view_mut.as_slice(), &[] as &[u32]);
+        assert_eq!(&*view_mut, &[] as &[u32]);
     }
 
     #[test]
@@ -427,12 +427,12 @@ mod tests {
         let view_ro = ListView::<u64>::unpack(&buf).unwrap();
         assert_eq!(view_ro.len(), length as usize);
         assert_eq!(view_ro.capacity(), capacity);
-        assert_eq!(view_ro.as_slice(), &items[..]);
+        assert_eq!(*view_ro, items[..]);
 
         let view_mut = ListView::<u64>::unpack_mut(&mut buf).unwrap();
         assert_eq!(view_mut.len(), length as usize);
         assert_eq!(view_mut.capacity(), capacity);
-        assert_eq!(view_mut.as_slice(), &items[..]);
+        assert_eq!(*view_mut, items[..]);
     }
 
     #[test]
@@ -619,14 +619,14 @@ mod tests {
                 let view_ro = ListView::<T, $LengthType>::unpack(&buf).unwrap();
                 assert_eq!(view_ro.len(), length_usize);
                 assert_eq!(view_ro.capacity(), capacity);
-                assert_eq!(view_ro.as_slice(), &items[..]);
+                assert_eq!(*view_ro, items[..]);
 
                 // Test mutable view
                 let mut buf_mut = buf.clone();
                 let view_mut = ListView::<T, $LengthType>::unpack_mut(&mut buf_mut).unwrap();
                 assert_eq!(view_mut.len(), length_usize);
                 assert_eq!(view_mut.capacity(), capacity);
-                assert_eq!(view_mut.as_slice(), &items[..]);
+                assert_eq!(*view_mut, items[..]);
 
                 // Test init
                 let mut init_buf = vec![0xFFu8; buf_size];

--- a/pod/src/list/list_view_read_only.rs
+++ b/pod/src/list/list_view_read_only.rs
@@ -3,6 +3,7 @@
 use {
     crate::{list::list_trait::List, pod_length::PodLength, primitives::PodU32},
     bytemuck::Pod,
+    std::ops::Deref,
 };
 
 #[derive(Debug)]
@@ -16,16 +17,17 @@ impl<T: Pod, L: PodLength> List for ListViewReadOnly<'_, T, L> {
     type Item = T;
     type Length = L;
 
-    fn len(&self) -> usize {
-        (*self.length).into()
-    }
-
     fn capacity(&self) -> usize {
         self.capacity
     }
+}
 
-    fn as_slice(&self) -> &[Self::Item] {
-        &self.data[..self.len()]
+impl<T: Pod, L: PodLength> Deref for ListViewReadOnly<'_, T, L> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        let len = (*self.length).into();
+        &self.data[..len]
     }
 }
 
@@ -89,8 +91,7 @@ mod tests {
         let view = ListView::<u32, PodU32>::unpack(&buffer).unwrap();
 
         // `as_slice()` should only return the first `len` items.
-        assert_eq!(view.as_slice(), &items[..]);
-        assert_eq!(view.as_slice().len(), view.len());
+        assert_eq!(*view, items[..]);
     }
 
     #[test]
@@ -138,7 +139,7 @@ mod tests {
         assert_eq!(view.len(), 0);
         assert_eq!(view.capacity(), 0);
         assert!(view.is_empty());
-        assert_eq!(view.as_slice(), &[]);
+        assert_eq!(*view, []);
     }
 
     #[test]
@@ -156,7 +157,7 @@ mod tests {
         // Check if the public API works as expected despite internal padding
         assert_eq!(view.len(), 2);
         assert_eq!(view.capacity(), 4);
-        assert_eq!(view.as_slice(), &items[..]);
+        assert_eq!(*view, items[..]);
     }
 
     #[test]
@@ -181,7 +182,7 @@ mod tests {
         let view = ListView::<u32>::unpack(&buffer).unwrap();
 
         // Get in-bounds elements
-        assert_eq!(view.get(0), Some(&10u32));
+        assert_eq!(view.first(), Some(&10u32));
         assert_eq!(view.get(1), Some(&20u32));
         assert_eq!(view.get(2), Some(&30u32));
 
@@ -196,6 +197,6 @@ mod tests {
     fn test_get_on_empty_list() {
         let buffer = build_test_buffer::<u32, PodU32>(0, 5, &[]);
         let view = ListView::<u32, PodU32>::unpack(&buffer).unwrap();
-        assert_eq!(view.get(0), None);
+        assert_eq!(view.first(), None);
     }
 }

--- a/pod/src/list/list_view_read_only.rs
+++ b/pod/src/list/list_view_read_only.rs
@@ -173,4 +173,29 @@ mod tests {
         assert_eq!(view.bytes_used().unwrap(), expected_used);
         assert_eq!(view.bytes_allocated().unwrap(), expected_cap);
     }
+
+    #[test]
+    fn test_get() {
+        let items = [10u32, 20, 30];
+        let buffer = build_test_buffer::<u32, PodU32>(items.len(), 5, &items);
+        let view = ListView::<u32>::unpack(&buffer).unwrap();
+
+        // Get in-bounds elements
+        assert_eq!(view.get(0), Some(&10u32));
+        assert_eq!(view.get(1), Some(&20u32));
+        assert_eq!(view.get(2), Some(&30u32));
+
+        // Get out-of-bounds element (index == len)
+        assert_eq!(view.get(3), None);
+
+        // Get way out-of-bounds
+        assert_eq!(view.get(100), None);
+    }
+
+    #[test]
+    fn test_get_on_empty_list() {
+        let buffer = build_test_buffer::<u32, PodU32>(0, 5, &[]);
+        let view = ListView::<u32, PodU32>::unpack(&buffer).unwrap();
+        assert_eq!(view.get(0), None);
+    }
 }

--- a/pod/src/slice.rs
+++ b/pod/src/slice.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        list::{List, ListView, ListViewMut, ListViewReadOnly},
+        list::{ListView, ListViewMut, ListViewReadOnly},
         primitives::PodU32,
     },
     bytemuck::Pod,


### PR DESCRIPTION
While working on auction mechanics, found myself needing a few new methods in ListView:
- get(&self, index: usize)
- get_mut(&mut self, index: usize)
- as_mut_slice(&mut self)
- sort(&mut self) and sort_by<F>(&mut self, ...)

This PR adds these methods to the respective trait + mut views. 

=======

EDIT: Adding deref trait implementation to ListViewMut & ListViewReadOnly to get the benefits above implicitly. 

