### PR TITLE
CI: Fix semver check job

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -55,11 +55,6 @@ jobs:
           cargo-cache-key: cargo-test-publish-${{ inputs.package_path }}
           cargo-cache-fallback-key: cargo-test-publish
 
-      - name: Install cargo-audit
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-semver-checks
-
       - name: Format
         run: pnpm zx ./scripts/rust/format.mjs "${{ inputs.package_path }}"
 
@@ -69,13 +64,45 @@ jobs:
       - name: Test
         run: pnpm zx ./scripts/rust/test.mjs "${{ inputs.package_path }}"
 
+  semver:
+    name: Check Semver
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          cargo-cache-key: cargo-publish-semver-${{ inputs.package_path }}
+          cargo-cache-fallback-key: cargo-publish-semver
+
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks,cargo-release
+
+      - name: Set Git Author (required for cargo-release)
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Set Version
+        run: |
+          if [ "${{ inputs.level }}" == "version" ]; then
+            LEVEL=${{ inputs.version }}
+          else
+            LEVEL=${{ inputs.level }}
+          fi
+          cargo release $LEVEL --manifest-path "${{ inputs.package_path }}/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
+
       - name: Check semver
-        run: pnpm rust:semver ${{ inputs.package_path }} --release-type ${{ inputs.level }}
+        run: pnpm rust:semver --manifest-path "${{ inputs.package_path }}/Cargo.toml"
 
   publish:
     name: Publish Rust Crate
     runs-on: ubuntu-latest
-    needs: test
+    needs: [semver, test]
     permissions:
       contents: write
     steps:

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "rust:audit": "zx ./scripts/rust/audit.mjs",
     "rust:publish": "zx ./scripts/rust/publish.mjs",
     "rust:hack": "zx ./scripts/rust/hack.mjs",
-    "rust:semver": "zx ./scripts/rust/semver.mjs"
+    "rust:semver": "cargo semver-checks"
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",

--- a/scripts/rust/semver.mjs
+++ b/scripts/rust/semver.mjs
@@ -1,7 +1,0 @@
-#!/usr/bin/env zx
-import 'zx/globals';
-import { cliArguments, getCargo, workingDirectory } from '../utils.mjs';
-
-const [folder, ...args] = cliArguments();
-const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
-await $`cargo semver-checks --manifest-path ${manifestPath} ${args}`;


### PR DESCRIPTION
#### Problem

The semver check job isn't properly bumping to the new proposed version before running, causing false negatives.

#### Summary of changes

Bring this repo's job in line with the others, which runs cargo release to bump the version before running semver-checks.