### PR TITLE
deps: Bump Rust up to same version as SDK repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ solana = "2.3.4"
 # Specify Rust toolchains for rustfmt, clippy, and build.
 # Any unprovided toolchains default to stable.
 [workspace.metadata.toolchains]
-nightly = "nightly-2025-02-16"
+nightly = "nightly-2025-06-29"
 
 [workspace.metadata.spellcheck]
 config = "scripts/spellcheck.toml"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.88.0"


### PR DESCRIPTION
#### Problem

The rust version used in this repo is a bit behind, which means that certain tools can't be installed.

#### Summary of changes

Get the rust version in line with the SDK.