### PR TITLE
CI: Only run semver-checks for lib crates, fix spelling issues

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -80,14 +80,27 @@ jobs:
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-semver-checks@0.42.0,cargo-release@0.25.18
+          tool: toml-cli,cargo-semver-checks@0.42.0,cargo-release@0.25.18
+
+      - name: Check if crate has a lib target
+        shell: bash
+        id: has_lib
+        run: |
+          toml get "${{ inputs.package_path }}/Cargo.toml" lib.crate-type | grep lib
+          if [[ $? -eq 1 ]]; then
+            echo "has_lib=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_lib=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set Git Author (required for cargo-release)
+        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
       - name: Set Version
+        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
         run: |
           if [ "${{ inputs.level }}" == "version" ]; then
             LEVEL=${{ inputs.version }}
@@ -97,6 +110,7 @@ jobs:
           cargo release $LEVEL --manifest-path "${{ inputs.package_path }}/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
 
       - name: Check semver
+        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
         run: pnpm rust:semver --manifest-path "${{ inputs.package_path }}/Cargo.toml"
 
   publish:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,16 @@
 resolver = "2"
 members = [
   "discriminator",
+  "discriminator/derive",
+  "discriminator/syn",
   "generic-token",
   "generic-token-tests",
   "pod",
   "program-error",
+  "program-error/derive",
   "tlv-account-resolution",
   "type-length-value",
+  "type-length-value/derive",
   "type-length-value-derive-test",
 ]
 

--- a/discriminator/Cargo.toml
+++ b/discriminator/Cargo.toml
@@ -21,7 +21,7 @@ spl-discriminator-derive = { version = "0.2.0", path = "./derive" }
 spl-discriminator = { path = ".", features = ["borsh"] }
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/discriminator/syn/Cargo.toml
+++ b/discriminator/syn/Cargo.toml
@@ -14,5 +14,8 @@ sha2 = "0.10"
 syn = { version = "2.0", features = ["full"] }
 thiserror = "1.0"
 
+[lib]
+crate-type = ["lib"]
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/discriminator/syn/src/error.rs
+++ b/discriminator/syn/src/error.rs
@@ -3,10 +3,10 @@
 /// Error types for the `hash_input` parser
 #[derive(Clone, Debug, Eq, thiserror::Error, PartialEq)]
 pub enum SplDiscriminateError {
-    /// Discriminator hash_input attribute not provided
+    /// Discriminator `hash_input` attribute not provided
     #[error("Discriminator `hash_input` attribute not provided")]
     HashInputAttributeNotProvided,
-    /// Error parsing discriminator hash_input attribute
+    /// Error parsing discriminator `hash_input` attribute
     #[error("Error parsing discriminator `hash_input` attribute")]
     HashInputAttributeParseError,
 }

--- a/discriminator/syn/src/lib.rs
+++ b/discriminator/syn/src/lib.rs
@@ -23,7 +23,7 @@ pub struct SplDiscriminateBuilder {
     pub generics: Generics,
     /// The item's where clause for generics (if any)
     pub where_clause: Option<WhereClause>,
-    /// The TLV hash_input
+    /// The TLV `hash_input`
     pub hash_input: String,
 }
 
@@ -99,7 +99,7 @@ impl From<&SplDiscriminateBuilder> for TokenStream {
     }
 }
 
-/// Returns the bytes for the TLV hash_input discriminator
+/// Returns the bytes for the TLV `hash_input` discriminator
 fn get_discriminator_bytes(hash_input: &str) -> LitByteStr {
     LitByteStr::new(
         &Sha256::digest(hash_input.as_bytes())[..8],

--- a/discriminator/syn/src/parser.rs
+++ b/discriminator/syn/src/parser.rs
@@ -10,8 +10,8 @@ use {
     },
 };
 
-/// Struct used for `syn` parsing of the hash_input attribute
-/// #[discriminator_hash_input("...")]
+/// Struct used for `syn` parsing of the `hash_input` attribute:
+/// `#[discriminator_hash_input("...")]`
 struct HashInputValueParser {
     value: LitStr,
     _comma: Option<Comma>,
@@ -25,7 +25,7 @@ impl Parse for HashInputValueParser {
     }
 }
 
-/// Parses the hash_input from the `#[discriminator_hash_input("...")]`
+/// Parses the `hash_input` from the `#[discriminator_hash_input("...")]`
 /// attribute
 pub fn parse_hash_input(attrs: &[Attribute]) -> Result<String, SplDiscriminateError> {
     match attrs

--- a/generic-token/Cargo.toml
+++ b/generic-token/Cargo.toml
@@ -15,3 +15,6 @@ solana-pubkey = { version = "3.0.0", default-features = false, features = [
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+crate-type = ["lib"]

--- a/pod/Cargo.toml
+++ b/pod/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0.142"
 base64 = { version = "0.22.1" }
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/program-error/Cargo.toml
+++ b/program-error/Cargo.toml
@@ -23,7 +23,7 @@ solana-sha256-hasher = "3.0.0"
 solana-sysvar = "3.0.0"
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/program-error/derive/src/lib.rs
+++ b/program-error/derive/src/lib.rs
@@ -44,7 +44,7 @@ pub fn to_str(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Proc macro attribute to turn your enum into a Solana Program Error
+/// Proc-macro attribute to turn your enum into a Solana Program Error
 ///
 /// Adds:
 /// - `Clone`

--- a/program-error/derive/src/macro_impl.rs
+++ b/program-error/derive/src/macro_impl.rs
@@ -133,7 +133,7 @@ pub fn spl_program_error(
 /// It will then check to make sure the provided `hash_error_code_start` is
 /// equal to the hash-produced `u32`.
 ///
-/// See https://docs.rs/syn/latest/syn/struct.Variant.html
+/// See the [`syn` docs](https://docs.rs/syn/latest/syn/struct.Variant.html).
 fn set_first_discriminant(item_enum: &mut ItemEnum, error_code_start: u32) {
     let enum_ident = &item_enum.ident;
     if item_enum.variants.is_empty() {
@@ -158,7 +158,7 @@ fn set_first_discriminant(item_enum: &mut ItemEnum, error_code_start: u32) {
 }
 
 /// Hashes the `SPL_ERROR_HASH_NAMESPACE` constant, the enum name and variant
-/// name and returns four middle bytes (13 through 16) as a u32.
+/// name and returns four middle bytes (13 through 16) as a `u32`.
 fn u32_from_hash(enum_ident: &Ident) -> u32 {
     let hash_input = format!("{}:{}", SPL_ERROR_HASH_NAMESPACE, enum_ident);
 

--- a/program-error/derive/src/parser.rs
+++ b/program-error/derive/src/parser.rs
@@ -15,7 +15,7 @@ pub struct SplProgramErrorArgs {
     /// Whether to hash the error codes using sha-256
     /// or to use the default error code assigned by `num_traits`.
     pub hash_error_code_start: Option<u32>,
-    /// Crate to use for solana_program_error
+    /// Crate to use for `solana_program_error`
     pub program_error_import: SolanaProgramError,
 }
 
@@ -72,8 +72,8 @@ impl Parse for SplProgramErrorArgs {
     }
 }
 
-/// Parser for args to the `#[spl_program_error]` attribute
-/// ie. `#[spl_program_error(hash_error_code_start = 1275525928)]`
+/// Parser for args to the `#[spl_program_error]` attribute.
+/// For example, `#[spl_program_error(hash_error_code_start = 1275525928)]`.
 enum SplProgramErrorArgParser {
     HashErrorCodes {
         _equals_sign: Token![=],

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -54,3 +54,4 @@ TLV
 const
 api/S
 APIs
+parsers

--- a/tlv-account-resolution/Cargo.toml
+++ b/tlv-account-resolution/Cargo.toml
@@ -32,7 +32,7 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/type-length-value/Cargo.toml
+++ b/type-length-value/Cargo.toml
@@ -25,7 +25,7 @@ spl-pod = { version = "0.7.0", path = "../pod" }
 thiserror = "2.0"
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/type-length-value/derive/src/lib.rs
+++ b/type-length-value/derive/src/lib.rs
@@ -1,4 +1,4 @@
-//! Crate defining a derive macro for a basic borsh implementation of
+//! Crate defining a derive macro for a basic `borsh` implementation of
 //! the trait `VariableLenPack`.
 
 #![deny(missing_docs)]


### PR DESCRIPTION
#### Problem

A publish failed on a proc-macro crate because semver-checks doesn't work on non-lib crates.

#### Summary of changes

Be a bit smarter, and only run semver-checks if the package has a crate-type that contains the word "lib", which means it'll catch `cdylib`, `rlib`, and `lib`.

At the same time, I removed `cdylib` from a few crates that didn't need it, and added a lib target to those that didn't explicitly declare it.

And finally, while adding the crates to the workspace, I had to fix some existing spelling mistakes that weren't caught before.