### PR TITLE
CI: Don't specify bash for the semver step

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -83,14 +83,15 @@ jobs:
           tool: toml-cli,cargo-semver-checks@0.42.0,cargo-release@0.25.18
 
       - name: Check if crate has a lib target
-        shell: bash
         id: has_lib
+        shell: bash
         run: |
-          toml get "${{ inputs.package_path }}/Cargo.toml" lib.crate-type | grep lib
-          if [[ $? -eq 1 ]]; then
-            echo "has_lib=false" >> "$GITHUB_OUTPUT"
-          else
+          set +e # toml crashes the whole shell if it fails to find the key
+          result=$(toml get "${{ inputs.package_path }}/Cargo.toml" lib.crate-type)
+          if [[ "$result" == *"lib"* ]]; then
             echo "has_lib=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_lib=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set Git Author (required for cargo-release)


### PR DESCRIPTION
#### Problem

The publish job fails for proc-macro crates because they don't specify a crate-type. This means that the first call to `toml get ...` fails, which causes the whole job to fail.

#### Summary of changes

Cargo issues a warning if you specify `crate-type = ["proc-macro"]`, so rather than creating a new warning, simply allow for errors when searching for the string.