### PR TITLE
dependabot: Only get security patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     interval: daily
     time: "08:00"
     timezone: UTC
-  open-pull-requests-limit: 6
+  open-pull-requests-limit: 0
 - package-ecosystem: npm
   directory: "/"
   schedule:


### PR DESCRIPTION
#### Problem

Dependabot updates all versions of packages, which is less flexible for end users. Libraries are more useful when dependencies are relaxed.

#### Summary of changes

Change the open pull request number to 0 to only enable security updates, as documented at
[Dependabot's documentation](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file)