### PR TITLE
collections: Put import behind `cfg`

### DIFF
--- a/collections/src/str.rs
+++ b/collections/src/str.rs
@@ -17,12 +17,14 @@ use borsh::{
     io::{ErrorKind, Read},
     BorshDeserialize, BorshSerialize,
 };
+#[cfg(any(feature = "borsh", feature = "wincode"))]
+use core::str::from_utf8;
 use {
     crate::{TrailingVec, U16PrefixedVec, U32PrefixedVec, U64PrefixedVec, U8PrefixedVec},
     core::{
         fmt::{Debug, Formatter},
         ops::Deref,
-        str::{from_utf8, from_utf8_unchecked},
+        str::from_utf8_unchecked,
     },
 };
 #[cfg(feature = "wincode")]


### PR DESCRIPTION
### Problem

There is a warning for unused import when building the `collections`.
```
warning: unused import: `from_utf8`
  --> src/str.rs:25:15
   |
25 |         str::{from_utf8, from_utf8_unchecked},
   |               ^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
```

### Solution

Put the import behind the features that use it.